### PR TITLE
Show CLI help by default (#3) and bump version

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -16,7 +16,7 @@ import * as errors from './errors.js';
 import { bundleModule } from './bundle.js';
 new Command()
     .name('minee')
-    .version('0.0.4')
+    .version('0.0.5')
     .description('📦 Earth Engine module bundler.')
     .arguments('<entry>')
     .option('-d --dest <path>', 'The local file path to write the bundled file.')
@@ -24,6 +24,7 @@ new Command()
     .action((entry, options) => __awaiter(void 0, void 0, void 0, function* () {
     yield runBundler(entry, options.dest, !options.header);
 }))
+    .showHelpAfterError()
     .parse(process.argv);
 function runBundler(entry, dest, noHeader = false) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { bundleModule } from './bundle.js'
 
 new Command()
   .name('minee')
-  .version('0.0.4')
+  .version('0.0.5')
   .description('📦 Earth Engine module bundler.')
   .arguments('<entry>')
   .option('-d --dest <path>', 'The local file path to write the bundled file.')
@@ -17,6 +17,7 @@ new Command()
   .action(async (entry: string, options: { dest: string, header: boolean }) => {
     await runBundler(entry, options.dest, !options.header)
   })
+  .showHelpAfterError()
   .parse(process.argv)
 
 /**


### PR DESCRIPTION
Close #3 by showing help if `minee` CLI is called incorrectly.

Bump version for release.