### PR TITLE
Add config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,40 @@ If you haven't accessed an Earth Engine repository using `git` from your compute
 ## CLI
 
 ```bash
-Usage: minee [options] <entry>
+Usage: minee [options]
 
 📦 Earth Engine module bundler.
 
 Options:
-  -V, --version      output the version number
-  -d, --dest <path>  The local file path to write the bundled module.
-  --no-header        Drop header information from the bundled file
-  -h, --help         display help for command
+  -V, --version       output the version number
+  -e, --entry <path>  The path to the module entry point, e.g. users/username/repository:module.
+  -d --dest <path>    The local file path to write the bundled file.
+  --no-header         Drop header information from the bundled file.
+  -h, --help          display help for command
 ```
 
 Pass an Earth Engine module path to the `minee` command, with an optional destination path to save the bundled module. For example, the following command...
 
 ```bash
-minee users/aazuspan/geeSharp:geeSharp --dest=./bundled
+minee --entry=users/aazuspan/geeSharp:geeSharp --dest=./bundled
 ```
 
 ...will download the `users/aazuspan/geeSharp` repository, find any modules required through the `geeSharp` module, bundle them into a single file, and save that to `./bundled`.
+
+### Configuration File
+
+To avoid entering CLI options every time `minee` is run, you can create a `.minee.json` configuration file in the root of your project where you run `minee`. An example configuration file is shown below:
+
+```javascript
+/* .minee.json */
+{
+  "entry": "users/aazuspan/geeSharp:geeSharp",
+  "dest": "./bundled",
+  "noHeader": false
+}
+```
+
+Now running `minee` with no options will produce the same results as before. `minee` prioritizes CLI options over configuration options, so you can override the configuration file by passing options as needed.
 
 ## JavaScript API
 

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -11,29 +11,62 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 import chalk from 'chalk';
 import tree from 'terminal-tree';
 import { Command } from 'commander';
-import path from 'path';
+import fs from "fs";
 import * as errors from './errors.js';
 import { bundleModule } from './bundle.js';
+function loadConfig() {
+    const defaultConfig = {
+        entry: undefined,
+        dest: undefined,
+        noHeader: false,
+    };
+    try {
+        const config = JSON.parse(fs.readFileSync(".minee.json", "utf8"));
+        return Object.assign(Object.assign({}, defaultConfig), config);
+    }
+    catch (err) {
+        return defaultConfig;
+    }
+}
 new Command()
     .name('minee')
     .version('0.0.5')
     .description('📦 Earth Engine module bundler.')
-    .arguments('<entry>')
+    .option('-e, --entry <path>', 'The path to the module entry point, e.g. users/username/repository:module.')
     .option('-d --dest <path>', 'The local file path to write the bundled file.')
     .option('--no-header', 'Drop header information from the bundled file.')
-    .action((entry, options) => __awaiter(void 0, void 0, void 0, function* () {
-    yield runBundler(entry, options.dest, !options.header);
+    .action((options) => __awaiter(void 0, void 0, void 0, function* () {
+    const config = loadConfig();
+    const entryPath = options.entry || config.entry;
+    const destPath = options.dest || config.dest;
+    const noHeader = options.header === false || config.noHeader;
+    if (entryPath === undefined) {
+        console.log(`
+      ${chalk.red('No entry point specified!')} Please specify an entry point using the -e or --entry options, or by adding an 'entry' property to your .minee.json configuration file.
+      `);
+        return;
+    }
+    yield runBundler(entryPath, destPath, noHeader);
 }))
     .showHelpAfterError()
     .parse(process.argv);
 function runBundler(entry, dest, noHeader = false) {
     return __awaiter(this, void 0, void 0, function* () {
+        let name;
+        try {
+            name = entry.split(':')[1].split('/').pop();
+            dest = dest || `./${name}.bundled.js`;
+            console.log(`Bundling ${chalk.blue(entry)} to ${chalk.yellow(dest)}...\n`);
+        }
+        catch (err) {
+            console.log(`
+      ${chalk.red('Invalid entry point!')} '${entry}' does not match the required format 'users/username/repository:module'.
+      `);
+            return;
+        }
         try {
             const bundled = yield bundleModule(entry, { noHeader });
-            if (dest === undefined) {
-                dest = path.resolve(`${bundled.entry.name}.bundled.js`);
-            }
-            const moduleTree = tree(bundled.entry.dependencyTree({ pretty: false }), {
+            const moduleTree = tree(bundled.entry.dependencyTree({ pretty: true }), {
                 symbol: false,
                 highlight: false,
                 padding: 4


### PR DESCRIPTION
This PR adds support for a configuration file `.minee.json` to replace any missing CLI options. In order to do that, we change `entry` from a required positional argument to an optional keyword argument.

Close #8