### PR TITLE
Add minifying options

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -1,0 +1,19 @@
+import fs from "fs";
+const CONFIG_PATH = "./.minee.json";
+function loadConfig() {
+    const defaultConfig = {
+        entry: undefined,
+        dest: undefined,
+        header: true,
+        minify: true,
+        keepNames: false,
+    };
+    try {
+        const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+        return Object.assign(Object.assign({}, defaultConfig), config);
+    }
+    catch (err) {
+        return defaultConfig;
+    }
+}
+export { loadConfig };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
+        "@babel/generator": "^7.19.0",
         "@babel/parser": "^7.19.1",
         "@babel/traverse": "^7.19.1",
         "@slimio/async-cli-spinner": "^0.5.2",
@@ -24,6 +25,7 @@
       },
       "devDependencies": {
         "@babel/types": "^7.18.13",
+        "@types/babel__generator": "^7.6.4",
         "@types/babel__traverse": "^7.18.1",
         "@types/node": "^18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.36.0",
@@ -476,6 +478,15 @@
       "integrity": "sha512-/IXhyOjKnXkKeJlkavbmY1VCkznwZeMDccCABQXrYtyfYLfF0Wjzubtf8+stIiGyy7jkZiZE5w2fVaH1XhzX5A==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
+      "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__traverse": {
@@ -5366,6 +5377,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@slimio/wcwidth/-/wcwidth-1.0.0.tgz",
       "integrity": "sha512-/IXhyOjKnXkKeJlkavbmY1VCkznwZeMDccCABQXrYtyfYLfF0Wjzubtf8+stIiGyy7jkZiZE5w2fVaH1XhzX5A=="
+    },
+    "@types/babel__generator": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
+      "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
     },
     "@types/babel__traverse": {
       "version": "7.18.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "exports": "./dist/index.js",
   "devDependencies": {
     "@babel/types": "^7.18.13",
+    "@types/babel__generator": "^7.6.4",
     "@types/babel__traverse": "^7.18.1",
     "@types/node": "^18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.36.0",
@@ -48,6 +49,7 @@
     "typescript": "^4.8.2"
   },
   "dependencies": {
+    "@babel/generator": "^7.19.0",
     "@babel/parser": "^7.19.1",
     "@babel/traverse": "^7.19.1",
     "@slimio/async-cli-spinner": "^0.5.2",

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,17 +1,25 @@
 import fs from 'fs'
 import tree from 'terminal-tree'
 import { transformSync } from 'esbuild'
+import _traverse, { NodePath } from '@babel/traverse'
+import _generator from "@babel/generator"
+import * as parser from '@babel/parser'
 
 import { loadModule, Module, DependencyTree } from './module.js'
+
+// See https://github.com/babel/babel/issues/13855
+const traverse = (_traverse as any).default
+const generate = (_generator as any).default
 
 /**
  * Wrap a module's source code for bundling.
  * @param {Module} module - The module to wrap.
+ * @param {string} requireIdentifier - The identifier to use for `require` calls. 
  * @return {string} The wrapped source code.
  */
-const wrapModule = (module: Module): string => {
+const wrapModule = (module: Module, requireIdentifier: string): string => {
   const wrapped = `"${module.path}":
-    function (exports, require) {
+    function (exports, ${requireIdentifier}) {
       ${module.code}
       return exports;
     },
@@ -50,52 +58,85 @@ Bundled by minee (${new Date().toISOString()}).*/\n\n`
 }
 
 /**
+ * Rename any `require` identifiers in a code block to avoid the Earth Engine Code Editor
+ * making automatic GET requests when it sees them.
+ * @param {string} code - A block of code.
+ * @param {string} to - The replacement name.
+ * @returns {string} The renamed code. This is re-generated from AST, so there may be formatting changes.
+ */
+const renameRequires = (code: string, to: string): string => {
+  const ast = parser.parse(code)
+  traverse(ast, {
+    enter(path: NodePath) {
+      if (path.isIdentifier({name: "require"})) {
+        path.node.name = to
+      }
+    }
+  })
+ return generate(ast, {retainLines: true}).code
+}
+
+/**
  * Bundle a module into a single file.
  * @param {string} entry - The path to the module entry point, e.g. "users/username/module:script".
  * @param {object} [options]
- * @param {boolean} [options.noHeader=false] - If false, a header will be included in the bundled file
+ * @param {boolean} [options.header=true] - If true, a header will be included in the bundled file
  * with information about the source and license for the bundled modules.
+ * @param {boolean} [options.minify=false] - If true, the bundled file will be minified.
+ * @param {boolean} [options.keepNames=false] - If true, all identifiers will be preserved while 
+ * minifying. Otherwise, minifying will mangle names to reduce file size (without affecting the public API).
  * @return {Promise<Bundle>} A promise that resolves to a Bundle object containing the bundled code.
  */
 async function bundleModule (
   entry: string,
-  { noHeader = false } = {}
+  { header = false, minify = true, keepNames = false } = {}
 ): Promise<Bundle> {
+  // If we're not going to mangle identifiers, we need to replace `require` to avoid the
+  // Code Editor making GET requests automatically.
+  const mangling = minify && !keepNames
+  const requireIdentifier = mangling ? "require" : "_requireBundled"
+
   const entryModule = await loadModule(entry)
   const modules = [entryModule, ...entryModule.listDependencies()]
-  const wrapped = modules.map((module) => wrapModule(module))
-  const header = noHeader ? '' : buildHeader(entryModule, modules)
+  const wrapped = modules.map((module) => wrapModule(module, requireIdentifier))
+  const head = header ? buildHeader(entryModule, modules) : ''
 
-  const result = `
-    var modules = {
-        ${wrapped.join('\n')}
-    };
-
-    function loads(modules, entry) {
-        var moduleCache = {};
+  let code = `
+  var modules = {
+    ${wrapped.join('\n')}
+  };
+  
+  function loads(modules, entry) {
+    var moduleCache = {};
+    
+    var ${requireIdentifier} = function (moduleName) {
+      if (moduleCache[moduleName]) {
+        return moduleCache[moduleName];
+      }
+      var exp = {};
+      moduleCache[moduleName] = exp;
       
-        var require = function (moduleName) {
-          if (moduleCache[moduleName]) {
-              return moduleCache[moduleName];
-          }
-          var exp = {};
-          moduleCache[moduleName] = exp;
-      
-          return modules[moduleName](exp, require);
+          return modules[moduleName](exp, ${requireIdentifier});
         };
-      
-        return require(entry);
+        
+        return ${requireIdentifier}(entry);
       }
 
       exports = loads(modules, "${entry}");
   `
-
-  const minified = transformSync(result, {
-    minify: true,
-    target: 'es5'
-  }).code
-  const output = `${header}${minified}`
-
+  // Rename any `require` call to prevent the Code Editor from automatically running them.
+  code = mangling ? code : renameRequires(code, requireIdentifier)
+  
+  if (minify) {
+    code = transformSync(code, {
+      minifyWhitespace: true,
+      minifySyntax: true,
+      minifyIdentifiers: !keepNames,
+      target: 'es5'
+    }).code
+  }
+  
+  const output = `${head}${code}`
   return new Bundle(output, entryModule, modules)
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,35 @@
+import fs from "fs";
+
+const CONFIG_PATH = "./.minee.json"
+
+type Config = {
+  entry?: string;
+  dest?: string;
+  header?: boolean;
+  minify?: boolean;
+  keepNames?: boolean;
+};
+
+/**
+ * Load bundling options from a local config file, swapping in defaults for missing options.
+ * @returns {Config} The configuration settings for bundling.
+ */
+function loadConfig(): Config {
+  const defaultConfig: Config = {
+    entry: undefined,
+    dest: undefined,
+    header: true,
+    minify: true,
+    keepNames: false,
+  };
+
+  try {
+    const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+    return { ...defaultConfig, ...config };
+  } catch (err) {
+    return defaultConfig;
+  }
+}
+
+export {loadConfig}
+export type {Config}


### PR DESCRIPTION
Close #14 by adding options to disable minifying or preserve identifiers when minifying. In the CLI, these are available as `--no-minify` and `--keep-names`. In the API or config file they're available as `minify` and `keepNames`.

As described in #14, if you bundle a module without mangling identifiers (either by turning off `minify` or turning on `keepNames`), Earth Engine would automatically make GET requests for any `require` calls in the code. To avoid that, this replaces those calls with `_requireBundled`, which hopefully will not clash with any user code. To do that replacement, we needed to modify the AST and turn it back into code, which required adding `@babel/generator` as a dependency.

Finally, configuration options and helpers were moved out of the `cli` module into the `config` module. 